### PR TITLE
Add Comm Section and more to ReactiveForms

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -508,7 +508,7 @@ export class MyService {
   constructor() {}
   
   get event$(): Observable<{message: string}> {
-    this.eventSubject.asObservable();
+    return this.eventSubject.asObservable();
   }
   
   publishEvent(event): {message: string} {
@@ -521,7 +521,7 @@ Smart Component: The smart component sets the observable from MyService as a pub
 
 ```js
 export class SmartComponent {
-  public event$: Observable<{message: string} = this.myService.event$;
+  public event$: Observable<{message: string}> = this.myService.event$;
 
   constructor(
     private myService: MyService

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -556,7 +556,7 @@ export class PresentationFooComponent {
 Presentation Bar component: This presentation component is getting passed the latest value from the eventSubject by the smart components subscription to the event$ observable. 
 
 ```js
-export class PresentationFooComponent {
+export class PresentationBarComponent {
   @Input() event: boolean;
  
   ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
Added examples of the preferred style to perform cross-component communication via a service. 
Added common style to setup reactive form, as well as obscure fact about select inputs.